### PR TITLE
Updated Config log args & now using methods for CanBreak logic

### DIFF
--- a/E2ETests/SetupConfig.cs
+++ b/E2ETests/SetupConfig.cs
@@ -11,9 +11,14 @@ public class SetupConfig : IFailFastConfig
     private SetupConfig() { }
     
     public int LogCount { get; set; }
-    public bool CanDebugBreak { get; set; } = true;
 
-    public void FailFastBreak(string caller, Guid? groupId, string routing, IEnumerable? context) => LogCount++;
+    
+    private bool _canBreak = true;
+    public bool GetCanDebugBreak() => _canBreak;
+    public void SetCanDebugBreak(bool authState) => _canBreak = authState;
+
+
+    public void FailFastBreak(string caller, string routing, object? context) => LogCount++;
 
     public void FailFastThrow(string caller, Exception error) => LogCount++;
 }

--- a/E2ETests/TestBreakConfig.cs
+++ b/E2ETests/TestBreakConfig.cs
@@ -9,10 +9,10 @@ public class TestBreakConfig
         // These tests all invoke Debugger.Break() and must be run manually
         FailFast.Initialize(SetupConfig.GetMock());
     }
-    
-    
-    private void BreakOn() => SetupConfig.GetMock().CanDebugBreak = true;
-    private void BreakOff() => SetupConfig.GetMock().CanDebugBreak = false;
+
+
+    private void BreakOn() => SetupConfig.GetMock().SetCanDebugBreak(true);
+    private void BreakOff() => SetupConfig.GetMock().SetCanDebugBreak(false);
     private void Reset() => SetupConfig.GetMock().LogCount = 0;
     private int LogCount => SetupConfig.GetMock().LogCount;
         

--- a/E2ETests/TestBreakExplicit.cs
+++ b/E2ETests/TestBreakExplicit.cs
@@ -11,7 +11,7 @@ public class TestBreakExplicit
     }
     
     
-    private void BreakOff() => SetupConfig.GetMock().CanDebugBreak = false;
+    private void BreakOff() => SetupConfig.GetMock().SetCanDebugBreak(false);
     private void Reset() => SetupConfig.GetMock().LogCount = 0;
     private int LogCount => SetupConfig.GetMock().LogCount;
         

--- a/FailFast/FailFast.cs
+++ b/FailFast/FailFast.cs
@@ -41,7 +41,7 @@ public class FailFast
     /// Note: you do not need to configure FF, but this path cannot fire Debugger.Break() without a configuration.
     /// </summary>
     public static IFailFastOperations When 
-        => new FailFastOperations(_instance?._config?.CanDebugBreak == true ? FailFastContext.ConfigBreak : FailFastContext.NoBreak);
+        => new FailFastOperations(Config?.GetCanDebugBreak() == true ? FailFastContext.ConfigBreak : FailFastContext.NoBreak);
 
 
     

--- a/FailFast/FailFast.csproj
+++ b/FailFast/FailFast.csproj
@@ -13,6 +13,7 @@
         <PackageTags>Defensive;Devleoper;Debug;Breakpoint;Logs</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Version>1.1.0</Version>
     </PropertyGroup>
 
 
@@ -44,12 +45,12 @@
 
     <Target Name="CopyFiles" AfterTargets="CoreBuild" Condition="$(Configuration) == 'Release'">
         <ItemGroup>
-            <PkgNew Include="$(SolutionDir)FailFast\bin\Release\*.nupkg"/>
-            <PkgOld Include="$(SolutionDir)Latest\*.nupkg"/>
+            <PkgNew Include="$(SolutionDir)FailFast\bin\Release\*.nupkg" />
+            <PkgOld Include="$(SolutionDir)Latest\*.nupkg" />
         </ItemGroup>
 
-        <Delete Files="@(PkgOld)"/>
-        <Copy SourceFiles="@(PkgNew)" DestinationFolder="$(SolutionDir)Latest\"/>
+        <Delete Files="@(PkgOld)" />
+        <Copy SourceFiles="@(PkgNew)" DestinationFolder="$(SolutionDir)Latest\" />
     </Target>
 
 </Project>

--- a/FailFast/FailFastInternal/FailFastOperations.cs
+++ b/FailFast/FailFastInternal/FailFastOperations.cs
@@ -23,7 +23,7 @@ internal readonly struct FailFastOperations : IFailFastOperations
             return false;
         
         if (_context != FailFastContext.ExplicitBreak)
-            FailFast.Config?.FailFastBreak(caller, null, "FailFast.When.Null", new[] {obj});
+            FailFast.Config?.FailFastBreak(caller, "FailFast.When.Null", obj);
         
         if (_context != FailFastContext.NoBreak && Debugger.IsAttached)
             Debugger.Break();
@@ -42,7 +42,7 @@ internal readonly struct FailFastOperations : IFailFastOperations
             return false;
         
         if (_context != FailFastContext.ExplicitBreak)
-            FailFast.Config?.FailFastBreak(caller, null, "FailFast.When.NotNull", new[] {obj});
+            FailFast.Config?.FailFastBreak(caller, "FailFast.When.NotNull", obj);
         
         if (_context != FailFastContext.NoBreak && Debugger.IsAttached)
             Debugger.Break();
@@ -61,7 +61,7 @@ internal readonly struct FailFastOperations : IFailFastOperations
             return false;
         
         if (_context != FailFastContext.ExplicitBreak)
-            FailFast.Config?.FailFastBreak(caller, null, "FailFast.When.True", new[] {test});
+            FailFast.Config?.FailFastBreak(caller, "FailFast.When.True", test);
         
         if (_context != FailFastContext.NoBreak && Debugger.IsAttached)
             Debugger.Break();
@@ -80,7 +80,7 @@ internal readonly struct FailFastOperations : IFailFastOperations
             return false;
         
         if (_context != FailFastContext.ExplicitBreak)
-            FailFast.Config?.FailFastBreak(caller, null, "FailFast.When.NotTrue", new[] {test});
+            FailFast.Config?.FailFastBreak(caller, "FailFast.When.NotTrue", test);
         
         if (_context != FailFastContext.NoBreak && Debugger.IsAttached)
             Debugger.Break();

--- a/FailFast/FailFastInternal/IFailFastConfig.cs
+++ b/FailFast/FailFastInternal/IFailFastConfig.cs
@@ -7,8 +7,9 @@ namespace System.Diagnostics.CodeAnalysis.FailFastInternal;
 /// Note that only code using TryBreak() &amp; Throws() will generate log data.
 /// </summary>
 public interface IFailFastConfig
-{
-    public bool CanDebugBreak { get; set; }
+{   
+    public bool GetCanDebugBreak();
+    public void SetCanDebugBreak(bool authState);
     
     /// <summary>
     /// Captures the presence of a bad result regardless of whether CanDebuggerBreak=True.
@@ -17,7 +18,7 @@ public interface IFailFastConfig
     /// </summary>
     /// <param name="caller">Method that invoked TryBreak()</param>
     /// <param name="result">The last IResult produced before the TryBreak() was called</param>
-    public void FailFastBreak(string caller, Guid? groupId, string routing, IEnumerable? context);
+    public void FailFastBreak(string caller, string routing, object? context);
     
     /// <summary>
     /// Captures exception data from the Throws() method

--- a/UnitTests/SetupConfig.cs
+++ b/UnitTests/SetupConfig.cs
@@ -11,9 +11,13 @@ public class SetupConfig : IFailFastConfig
     private SetupConfig() { }
     
     public int LogCount { get; set; }
-    public bool CanDebugBreak { get => false; set => _ = value; }
 
-    public void FailFastBreak(string caller, Guid? groupId, string routing, IEnumerable? context) => LogCount++;
+
+    public bool GetCanDebugBreak() => false;
+    public void SetCanDebugBreak(bool authState){}
+    
+
+    public void FailFastBreak(string caller, string routing, object? context) => LogCount++;
 
     public void FailFastThrow(string caller, Exception error) => LogCount++;
 }


### PR DESCRIPTION
The switch to the CanBreak methods drastically improves the ability to fire/forget blind set the CanDebuggerBreak. Still leaves all the control on whether it will be set to the IFailFastConfig implementation.